### PR TITLE
fixed promise chain in fontGot

### DIFF
--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ import fontGot from './';
 
 var tmp = tmpdir('got-google-fonts');
 
-test(t => {
+test('pass', t => {
 	return fontGot(tmp, 'Droid Sans', {
 		variant: 'regular'
 	})
@@ -14,5 +14,14 @@ test(t => {
 		t.true(fs.existsSync(res[0]));
 	}, () => {
 		t.fail('Failed');
+	});
+});
+
+test('fail', t => {
+	return fontGot(tmp, 'HTTP400')
+	.then(() => {
+		t.fail('Failed');
+	}, (err) => {
+		t.true(err.statusCode === 400);
 	});
 });


### PR DESCRIPTION
Hey Jimmy,

I just came across a little bug in this module. When running the following snippet I would expect that the error from the google api is handled by the catch clause but instead it will throw a UnhandledPromiseRejectionWarning.

```js
const g = require('got-google-fonts');

g(`${__dirname}/fonts`, 'resultsInHTTP400')
.then(console.log)
.catch(console.error);
```

In this PR I've rewritten the promise chain in fontGot so errors are properly handled by catch clauses. Would be awesome if you accept the PR and release an updated version. :-)

Thanks,

Simon